### PR TITLE
Use new image proxy

### DIFF
--- a/src/app/services/indexer/tzkt/tzkt.service.ts
+++ b/src/app/services/indexer/tzkt/tzkt.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@angular/core';
-import { CONSTANTS } from '../../../../environments/environment';
-import { Indexer } from '../indexer.service';
+import {Injectable} from '@angular/core';
+import {CONSTANTS} from '../../../../environments/environment';
+import {Indexer} from '../indexer.service';
 import * as cryptob from 'crypto-browserify';
-import { WalletObject, Activity } from '../../wallet/wallet';
+import {Activity, WalletObject} from '../../wallet/wallet';
 import assert from 'assert';
 
 interface TokenMetadata {
@@ -293,8 +293,7 @@ export class TzktService implements Indexer {
     } else if (!CONSTANTS.MAINNET && (uri.startsWith('http://localhost') || uri.startsWith('http://127.0.0.1'))) {
       url = uri;
     }
-    const cacheUrl = await this.fetchApi(`https://k4ullpx9yd.execute-api.us-east-1.amazonaws.com/400x400?img=${url}`);
-    return cacheUrl ? cacheUrl : '';
+    return `https://k4ullpx9yd.execute-api.us-east-1.amazonaws.com/400x400?img=${url}`;
   }
   async fetchApi(url: string): Promise<any> {
     return fetch(url)

--- a/src/app/services/indexer/tzkt/tzkt.service.ts
+++ b/src/app/services/indexer/tzkt/tzkt.service.ts
@@ -293,7 +293,7 @@ export class TzktService implements Indexer {
     } else if (!CONSTANTS.MAINNET && (uri.startsWith('http://localhost') || uri.startsWith('http://127.0.0.1'))) {
       url = uri;
     }
-    const cacheUrl = await this.fetchApi(`https://www.tezos.help/api/img-proxy/?url=${url}`);
+    const cacheUrl = await this.fetchApi(`https://k4ullpx9yd.execute-api.us-east-1.amazonaws.com/400x400?img=${url}`);
     return cacheUrl ? cacheUrl : '';
   }
   async fetchApi(url: string): Promise<any> {


### PR DESCRIPTION
This uses the new image proxy, unlike the old one here we can also request maximum size for all images,
currently set to max 400 by 400


There is a test site running here that uses this branch, on (cloudflare pages)

https://tulip-kukai-test.pages.dev

But for some reason i cant test it with some Hen nfts, stuck at this stage forever:
![image](https://user-images.githubusercontent.com/40353667/124126152-aa1fad00-da7a-11eb-8f09-d8d154f8b504.png)

Not sure why that happens