### PR TITLE
Ensures facebook access token is invalidated before logging in

### DIFF
--- a/src/app/services/torus/torus.service.ts
+++ b/src/app/services/torus/torus.service.ts
@@ -251,7 +251,7 @@ export class TorusService {
       }
       if (selectedVerifier === FACEBOOK) {
         console.log('Invalidating access token...');
-        fetch(`https://graph.facebook.com/me/permissions?access_token=${loginDetails.userInfo.accessToken}`, { method: 'DELETE', mode: 'cors' });
+        await fetch(`https://graph.facebook.com/me/permissions?access_token=${loginDetails.userInfo.accessToken}`, { method: 'DELETE', mode: 'cors' });
       }
       const keyPair = skipTorusKey && !loginDetails?.privateKey ? { pk: '', pkh: '' } : this.operationService.spPrivKeyToKeyPair(loginDetails.privateKey);
       console.log('DirectAuth KeyPair', keyPair);


### PR DESCRIPTION
The exception will not be caught (see lines bellow) without `awaiting` on the result of the token invalidation callback. If that invalidation api call **fails**, logging in will happen as usual. Ideally, if the the `status` is not ok, a `new Error('Facebook user access token invalidation failed')` should be thrown, but I leave that to the maintainers to decide

https://github.com/kukai-wallet/kukai/blob/d0451c7070741e9ff465c66622b3ec3baf660569/src/app/services/torus/torus.service.ts#L267-L270